### PR TITLE
Maid 554 create maid account

### DIFF
--- a/src/maidsafe/vault/maid_manager/service.h
+++ b/src/maidsafe/vault/maid_manager/service.h
@@ -203,20 +203,14 @@ class MaidManagerService {
 
   struct MaidAccountCreationStatus {
     MaidAccountCreationStatus(passport::PublicMaid::Name maid_name_in,
-                              passport::PublicAnmaid::Name anmaid_name_in,
-                              nfs::MessageId maid_message_id_in,
-                              nfs::MessageId anmaid_message_id_in)
+                              passport::PublicAnmaid::Name anmaid_name_in)
         : maid_name(std::move(maid_name_in)),
           anmaid_name(std::move(anmaid_name_in)),
-          maid_message_id(std::move(maid_message_id_in)),
-          anmaid_message_id(std::move(anmaid_message_id_in)),
           maid_stored(false),
           anmaid_stored(false) {}
 
     passport::PublicMaid::Name maid_name;
     passport::PublicAnmaid::Name anmaid_name;
-    nfs::MessageId maid_message_id;
-    nfs::MessageId anmaid_message_id;
     bool maid_stored, anmaid_stored;
   };
 
@@ -251,7 +245,6 @@ class MaidManagerService {
   AccountTransferHandler<MaidManager> account_transfer_;
   std::mutex pending_account_mutex_;
   std::map<nfs::MessageId, MaidAccountCreationStatus> pending_account_map_;
-  std::map<nfs::MessageId, nfs::MessageId> reverse_pending_account_message_id_;
 };
 
 template <typename MessageType>


### PR DESCRIPTION
MAID-554 Fixes MaidSafe::error 'Attempt to overwrite existing unique data' during MAID account creation, by sending Put Maid and Put AnMaid with a new message id (with HashStringToMessageId() ). 
EDIT: new message_id is generated by XOR original message_id with hash(Maid/AnMaid).  Reverse dictionary is removed.
(OLD: Most conservative approach introduces a reverse dictionary for recovering the original message_id when response is received.)
