### PR TITLE
Maid 617

### DIFF
--- a/src/maidsafe/vault/data_manager/service.cc
+++ b/src/maidsafe/vault/data_manager/service.cc
@@ -460,21 +460,15 @@ void DataManagerService::HandleAccountTransfer(const AccountType& account) {
 
 void DataManagerService::HandleChurnEvent(
     std::shared_ptr<routing::CloseNodesChange> close_nodes_change) {
-//   LOG(kVerbose) << "HandleChurnEvent close_nodes_change_ containing following info before : ";
-//   close_nodes_change_.Print();
   std::lock_guard<std::mutex> lock(close_nodes_change_mutex_);
   if (stopped_)
     return;
-//   LOG(kVerbose) << "HandleChurnEvent close_nodes_change containing following info : ";
-//   close_nodes_change->Print();
   close_nodes_change_ = *close_nodes_change;
 
   Db<DataManager::Key, DataManager::Value>::TransferInfo transfer_info(
       db_.GetTransferInfo(close_nodes_change));
   for (auto& transfer : transfer_info)
     TransferAccount(transfer.first, transfer.second);
-//   LOG(kVerbose) << "HandleChurnEvent close_nodes_change_ containing following info after : ";
-//   close_nodes_change_.Print();
   PmidName pmid_name(Identity(close_nodes_change->lost_node().string()));
   std::map<DataManager::Key, DataManager::Value> accounts(db_.GetRelatedAccounts(pmid_name));
   for (auto& account : accounts)

--- a/src/maidsafe/vault/data_manager/service.cc
+++ b/src/maidsafe/vault/data_manager/service.cc
@@ -261,7 +261,7 @@ uint64_t DataManagerService::Replicate(const DataManager::Key& key, nfs::Message
       storing_pmid_nodes.push_back(tried_pmid_node);
   }
   catch (const maidsafe_error& error) {
-    if (error.code() == make_error_code(CommonErrors::no_such_element)) {
+    if (error.code() == make_error_code(VaultErrors::no_such_account)) {
       LOG(kInfo) << "No value in db so far...";
       return chunk_size;
     }
@@ -278,7 +278,7 @@ uint64_t DataManagerService::Replicate(const DataManager::Key& key, nfs::Message
   auto pmid_name(detail::GetRandomCloseNode(routing_, storing_pmid_nodes));
   if (!pmid_name) {
     LOG(kError) << "Failed to find a valid close pmid node";
-    return chunk_size;
+    return 0;
   }
 
   LruCacheGetResult get_result;
@@ -501,8 +501,8 @@ void DataManagerService::TransferAccount(const NodeId& dest,
                   << " to " << HexSubstr(dest.string())
                   << " with vaule " << account.second.Print();
   }
-  LOG(kVerbose) << "DataManagerService::TransferAccount send account_transfer";
-  dispatcher_.SendAccountTransfer(dest, account_transfer_proto.SerializeAsString());
+  if (!accounts.empty())
+    dispatcher_.SendAccountTransfer(dest, account_transfer_proto.SerializeAsString());
 }
 
 template <>

--- a/src/maidsafe/vault/data_manager/service.h
+++ b/src/maidsafe/vault/data_manager/service.h
@@ -578,7 +578,7 @@ void DataManagerService::HandleGet(const typename Data::Name& data_name,
       if (stopped_)
         return;
     }
-    
+
     this->DoHandleGetResponse<Data, RequestorIdType>(pmid_node_and_contents.first,
                                                      pmid_node_and_contents.second,
                                                      get_response_op);

--- a/src/maidsafe/vault/data_manager/tests/service_test.cc
+++ b/src/maidsafe/vault/data_manager/tests/service_test.cc
@@ -331,7 +331,6 @@ TEST_F(DataManagerServiceTest, BEH_Get) {
   data_manager_service_.Stop();
 }
 
-
 TEST_F(DataManagerServiceTest, BEH_SyncPut) {
     ImmutableData data(NonEmptyString(RandomString(kTestChunkSize)));
     DataManager::Key key(data.name());

--- a/src/maidsafe/vault/data_manager/tests/service_test.cc
+++ b/src/maidsafe/vault/data_manager/tests/service_test.cc
@@ -53,20 +53,20 @@ class DataManagerServiceTest : public testing::Test {
     data_manager_service_.get_timer_.AddTask(detail::Parameters::kDefaultTimeout, functor, required,
                                              task_id);
   }
-  
+
   void CancelGetTimerTask(int task_id) {
     data_manager_service_.get_timer_.CancelTask(task_id);
   }
-  
+
   void DeleteFromLruCache(const DataManager::Key& key) {
     data_manager_service_.lru_cache_.Delete(key);
   }
-  
+
   template <typename Data>
   void GetForReplication(const PmidName& pmid_name, const typename Data::Name& data_name) {
     data_manager_service_.GetForReplication<Data>(pmid_name, data_name);
   }
-  
+
   void AddToCloseNodesChange(const PmidName& pmid_name) {
     data_manager_service_.close_nodes_change_  =
         routing::CloseNodesChange(routing_.kNodeId(), std::vector<NodeId>(),
@@ -373,7 +373,7 @@ TEST_F(DataManagerServiceTest, BEH_AddPmidNoAccount) {
     EXPECT_NO_THROW(SendSync<DataManager::UnresolvedAddPmid>(group_unresolved_action,
                                                              group_source));
   }
-} 
+}
 
 TEST_F(DataManagerServiceTest, BEH_AddPmid) {
   ImmutableData data(NonEmptyString(RandomString(kTestChunkSize)));
@@ -509,10 +509,10 @@ TEST_F(DataManagerServiceTest, BEH_DoHandleGetResponse) {
   nfs_vault::DataNameAndContentOrCheckResult response(data_name, data.Serialise());
   auto get_response(CreateMessage<GetResponseFromPmidNodeToDataManager>(response));
   get_response.id = get_request.id;
-  Sleep(std::chrono::seconds(1));
   EXPECT_NO_THROW(SingleSendsToSingle(&data_manager_service_, get_response,
                                       routing::SingleSource(NodeId(pmid_name->string())),
                                       routing::SingleId(data_name_id)));
+  Sleep(std::chrono::seconds(1));
   EXPECT_EQ(Get(key).chunk_size(), kTestChunkSize);
   data_manager_service_.Stop();
 }

--- a/src/maidsafe/vault/data_manager/tests/service_test.cc
+++ b/src/maidsafe/vault/data_manager/tests/service_test.cc
@@ -18,12 +18,8 @@
 
 #include "maidsafe/common/test.h"
 #include "maidsafe/common/asio_service.h"
-
 #include "maidsafe/passport/passport.h"
-
 #include "maidsafe/routing/routing_api.h"
-#include "maidsafe/routing/parameters.h"
-
 #include "maidsafe/nfs/client/data_getter.h"
 
 #include "maidsafe/vault/data_manager/service.h"
@@ -54,35 +50,12 @@ class DataManagerServiceTest : public testing::Test {
                                              task_id);
   }
 
-  void CancelGetTimerTask(int task_id) {
-    data_manager_service_.get_timer_.CancelTask(task_id);
-  }
-
-  void DeleteFromLruCache(const DataManager::Key& key) {
-    data_manager_service_.lru_cache_.Delete(key);
-  }
-
-  template <typename Data>
-  void GetForReplication(const PmidName& pmid_name, const typename Data::Name& data_name) {
-    data_manager_service_.GetForReplication<Data>(pmid_name, data_name);
-  }
-
-  void AddToCloseNodesChange(const PmidName& pmid_name) {
-    data_manager_service_.close_nodes_change_  =
-        routing::CloseNodesChange(routing_.kNodeId(), std::vector<NodeId>(),
-                                  std::vector<NodeId> { NodeId(pmid_name->string()) });
-  }
-
   template <typename ActionType>
   void Commit(const DataManager::Key& key, const ActionType& action) {
     data_manager_service_.db_.Commit(key, action);
   }
 
   DataManager::Value Get(const DataManager::Key& key) { return data_manager_service_.db_.Get(key); }
-  uint64_t Replicate(const DataManager::Key& key, nfs::MessageId message_id,
-                     const PmidName& tried_pmid_node = PmidName()) {
-    return data_manager_service_.Replicate(key, message_id, tried_pmid_node);
-  }
 
   template <typename UnresolvedActionType>
   std::vector<std::unique_ptr<UnresolvedActionType>> GetUnresolvedActions();
@@ -112,16 +85,6 @@ void DataManagerServiceTest::SendSync(
     const std::vector<UnresolvedActionType>& /*unresolved_actions*/,
     const std::vector<routing::GroupSource>& /*group_source*/) {
   UnresolvedActionType::No_genereic_handler_is_available__Specialisation_is_required;
-}
-
-template <>
-void DataManagerServiceTest::SendSync<DataManager::UnresolvedPut>(
-     const std::vector<DataManager::UnresolvedPut>& unresolved_actions,
-     const std::vector<routing::GroupSource>& group_source) {
-  AddLocalActionAndSendGroupActions<DataManagerService, DataManager::UnresolvedPut,
-                                    SynchroniseFromDataManagerToDataManager>(
-     &data_manager_service_, data_manager_service_.sync_puts_, unresolved_actions,
-     group_source);
 }
 
 template <>
@@ -235,30 +198,6 @@ TEST_F(DataManagerServiceTest, BEH_Various) {
                                        routing::SingleSource(maid_node_id),
                                        routing::GroupId(data_name_id)));
   }
-  //  GetRequestFromMaidNodePartialToDataManager
-  {
-    NodeId data_name_id, maid_node_id(RandomString(NodeId::kSize));
-    auto content(CreateContent<nfs::GetRequestFromMaidNodePartialToDataManager::Contents>());
-    data_name_id = NodeId(content.raw_name.string());
-    auto get_request(CreateMessage<nfs::GetRequestFromMaidNodePartialToDataManager>(content));
-    EXPECT_NO_THROW(SingleRelaySendsToGroup(
-        &data_manager_service_, get_request,
-        routing::SingleRelaySource(routing::SingleSource(maid_node_id), maid_node_id,
-                                   routing::SingleSource(maid_node_id)),
-        routing::GroupId(data_name_id)));
-  }
-    //  GetRequestFromDataGetterPartialToDataManager
-    {
-        NodeId data_name_id, maid_node_id(RandomString(NodeId::kSize));
-        auto content(CreateContent<nfs::GetRequestFromDataGetterPartialToDataManager::Contents>());
-        data_name_id = NodeId(content.raw_name.string());
-        auto get_request(CreateMessage<nfs::GetRequestFromDataGetterPartialToDataManager>(content));
-        EXPECT_NO_THROW(SingleRelaySendsToGroup(
-            &data_manager_service_, get_request,
-            routing::SingleRelaySource(routing::SingleSource(maid_node_id), maid_node_id,
-                                       routing::SingleSource(maid_node_id)),
-            routing::GroupId(data_name_id)));
-    }
   //  GetResponseFromPmidNodeToDataManager
   {
     NodeId pmid_node_id(RandomString(NodeId::kSize));
@@ -313,35 +252,6 @@ TEST_F(DataManagerServiceTest, BEH_Put) {
   EXPECT_EQ(Get(key).chunk_size(), kTestChunkSize);
 }
 
-TEST_F(DataManagerServiceTest, BEH_Get) {
-  auto content(CreateContent<nfs::GetRequestFromMaidNodeToDataManager::Contents>());
-  PmidName pmid_name(Identity(RandomString(64)));
-  DataManager::Key key(content.raw_name, content.type);
-  Commit(key, ActionDataManagerPut(kTestChunkSize, nfs::MessageId(RandomInt32())));
-  Commit(key, ActionDataManagerAddPmid(pmid_name));
-  this->DeleteFromLruCache(key);
-  this->AddToCloseNodesChange(pmid_name);
-  NodeId maid_node_id(RandomString(NodeId::kSize)),
-  data_name_id { NodeId(content.raw_name.string()) };
-  auto get_request(CreateMessage<nfs::GetRequestFromMaidNodeToDataManager>(content));
-  EXPECT_NO_THROW(SingleSendsToGroup(&data_manager_service_, get_request,
-                                     routing::SingleSource(maid_node_id),
-                                     routing::GroupId(data_name_id)));
-  EXPECT_EQ(Get(key).chunk_size(), kTestChunkSize);
-  data_manager_service_.Stop();
-}
-
-TEST_F(DataManagerServiceTest, BEH_SyncPut) {
-    ImmutableData data(NonEmptyString(RandomString(kTestChunkSize)));
-    DataManager::Key key(data.name());
-    auto group_source(CreateGroupSource(data.name()));
-    ActionDataManagerPut action_put(kTestChunkSize, nfs::MessageId(RandomInt32()));
-    auto group_unresolved_action(
-        CreateGroupUnresolvedAction<DataManager::UnresolvedPut>(key, action_put, group_source));
-    SendSync<DataManager::UnresolvedPut>(group_unresolved_action, group_source);
-    EXPECT_NO_THROW(Get(key));
-}
-
 TEST_F(DataManagerServiceTest, BEH_Delete) {
   PmidName pmid_name(Identity(RandomString(64)));
   ImmutableData data(NonEmptyString(RandomString(kTestChunkSize)));
@@ -357,21 +267,6 @@ TEST_F(DataManagerServiceTest, BEH_Delete) {
       CreateGroupUnresolvedAction<DataManager::UnresolvedDelete>(key, action_delete, group_source));
   SendSync<DataManager::UnresolvedDelete>(group_unresolved_action, group_source);
   EXPECT_ANY_THROW(Get(key));
-}
-
-TEST_F(DataManagerServiceTest, BEH_AddPmidNoAccount) {
-  ImmutableData data(NonEmptyString(RandomString(kTestChunkSize)));
-  DataManager::Key key(data.name());
-  auto group_source(CreateGroupSource(data.name()));
-  {
-    PmidName pmid_name(Identity(RandomString(64)));
-    ActionDataManagerAddPmid action_add_pmid(pmid_name);
-    auto group_unresolved_action(CreateGroupUnresolvedAction<
-                                 DataManager::UnresolvedAddPmid>(key, action_add_pmid,
-                                                                 group_source));
-    EXPECT_NO_THROW(SendSync<DataManager::UnresolvedAddPmid>(group_unresolved_action,
-                                                             group_source));
-  }
 }
 
 TEST_F(DataManagerServiceTest, BEH_AddPmid) {
@@ -421,99 +316,6 @@ TEST_F(DataManagerServiceTest, BEH_RemovePmid) {
       key, action_remove_pmid, group_source));
   SendSync<DataManager::UnresolvedRemovePmid>(group_unresolved_action, group_source);
   EXPECT_TRUE(Get(key).AllPmids().size() == 1);
-}
-
-TEST_F(DataManagerServiceTest, BEH_ReplicateWithNoEntry) {
-  ImmutableData data(NonEmptyString(RandomString(kTestChunkSize)));
-  EXPECT_EQ(Replicate(vault::Key(data.name()), nfs::MessageId(RandomUint32())), 0);
-}
-
-TEST_F(DataManagerServiceTest, BEH_ReplicateNoPmid) {
-  ImmutableData data(NonEmptyString(RandomString(kTestChunkSize)));
-  DataManager::Key key(data.name());
-  Commit(key, ActionDataManagerPut(kTestChunkSize, nfs::MessageId(RandomUint32())));
-  EXPECT_EQ(Replicate(vault::Key(data.name()), nfs::MessageId(RandomUint32())), 0);
-}
-
-TEST_F(DataManagerServiceTest, BEH_AccountTransferFromDataManagerToDataManager) {
-  ImmutableData data(NonEmptyString(RandomString(kTestChunkSize)));
-  DataManager::Key key(data.name());
-  DataManagerValue value(kTestChunkSize);
-  protobuf::AccountTransfer account_transfer_proto;
-  protobuf::DataManagerKeyValuePair kv_msg;
-  kv_msg.set_key(key.Serialise());
-  kv_msg.set_value(value.Serialise());
-  account_transfer_proto.add_serialised_accounts(kv_msg.SerializeAsString());
-  auto content(AccountTransferFromDataManagerToDataManager::Contents(
-                   account_transfer_proto.SerializeAsString()));
-  auto account_transfer(CreateMessage<AccountTransferFromDataManagerToDataManager>(content));
-  for (unsigned int index(0); index < routing::Parameters::group_size - 1; ++index) {
-    EXPECT_NO_THROW(SingleSendsToSingle(
-        &data_manager_service_, account_transfer,
-        routing::SingleSource(NodeId(RandomString(NodeId::kSize))),
-        routing::SingleId(routing_.kNodeId())));
-  }
-  EXPECT_NO_THROW(Get(key));
-}
-
-TEST_F(DataManagerServiceTest, BEH_AccountQueryResponseFromDataManagerToDataManager) {
-  ImmutableData data(NonEmptyString(RandomString(kTestChunkSize)));
-  DataManager::Key key(data.name());
-  DataManagerValue value(kTestChunkSize);
-  protobuf::AccountTransfer account_transfer_proto;
-  protobuf::DataManagerKeyValuePair kv_msg;
-  auto group_source(CreateGroupSource(NodeId(data.name()->string())));
-  kv_msg.set_key(key.Serialise());
-  kv_msg.set_value(value.Serialise());
-  account_transfer_proto.add_serialised_accounts(kv_msg.SerializeAsString());
-  auto content(AccountQueryResponseFromDataManagerToDataManager::Contents(
-                   account_transfer_proto.SerializeAsString()));
-  auto account_transfer(CreateMessage<AccountQueryResponseFromDataManagerToDataManager>(content));
-  EXPECT_NO_THROW(GroupSendToSingle(&data_manager_service_, account_transfer, group_source,
-                                    routing::SingleId(routing_.kNodeId())));
-  EXPECT_NO_THROW(Get(key));
-}
-
-TEST_F(DataManagerServiceTest, BEH_GetForReplication) {
-  ImmutableData data(NonEmptyString(RandomString(kTestChunkSize)));
-  PmidName pmid_name(Identity(RandomString(64)));
-  DataManager::Key key(data.name());
-  Commit(key, ActionDataManagerPut(kTestChunkSize, nfs::MessageId(RandomInt32())));
-  Commit(key, ActionDataManagerAddPmid(pmid_name));
-  this->DeleteFromLruCache(key);
-  this->AddToCloseNodesChange(pmid_name);
-  NodeId maid_node_id(RandomString(NodeId::kSize)),
-  data_name_id { NodeId(data.name()->string()) };
-  this->GetForReplication<ImmutableData>(PmidName(Identity(RandomString(64))), data.name());
-  EXPECT_EQ(Get(key).chunk_size(), kTestChunkSize);
-  data_manager_service_.Stop();
-}
-
-TEST_F(DataManagerServiceTest, BEH_DoHandleGetResponse) {
-  ImmutableData data(NonEmptyString(RandomString(kTestChunkSize)));
-  auto data_name(data.name());
-  PmidName pmid_name(Identity(RandomString(64)));
-  DataManager::Key key(data_name);
-  Commit(key, ActionDataManagerPut(kTestChunkSize, nfs::MessageId(RandomInt32())));
-  Commit(key, ActionDataManagerAddPmid(pmid_name));
-  this->DeleteFromLruCache(key);
-  this->AddToCloseNodesChange(pmid_name);
-  NodeId maid_node_id(RandomString(NodeId::kSize)),
-  data_name_id { NodeId(data_name->string()) };
-  auto get_request(CreateMessage<nfs::GetRequestFromMaidNodeToDataManager>(
-                       nfs_vault::DataName(data_name)));
-  EXPECT_NO_THROW(SingleSendsToGroup(&data_manager_service_, get_request,
-                                     routing::SingleSource(maid_node_id),
-                                     routing::GroupId(data_name_id)));
-  nfs_vault::DataNameAndContentOrCheckResult response(data_name, data.Serialise());
-  auto get_response(CreateMessage<GetResponseFromPmidNodeToDataManager>(response));
-  get_response.id = get_request.id;
-  EXPECT_NO_THROW(SingleSendsToSingle(&data_manager_service_, get_response,
-                                      routing::SingleSource(NodeId(pmid_name->string())),
-                                      routing::SingleId(data_name_id)));
-  Sleep(std::chrono::seconds(1));
-  EXPECT_EQ(Get(key).chunk_size(), kTestChunkSize);
-  data_manager_service_.Stop();
 }
 
 }  //  namespace test

--- a/src/maidsafe/vault/data_manager/tests/service_test.cc
+++ b/src/maidsafe/vault/data_manager/tests/service_test.cc
@@ -198,6 +198,18 @@ TEST_F(DataManagerServiceTest, BEH_Various) {
                                        routing::SingleSource(maid_node_id),
                                        routing::GroupId(data_name_id)));
   }
+  //  GetRequestFromMaidNodePartialToDataManager
+  {
+    NodeId data_name_id, maid_node_id(RandomString(NodeId::kSize));
+    auto content(CreateContent<nfs::GetRequestFromMaidNodePartialToDataManager::Contents>());
+    data_name_id = NodeId(content.raw_name.string());
+    auto get_request(CreateMessage<nfs::GetRequestFromMaidNodePartialToDataManager>(content));
+    EXPECT_NO_THROW(SingleRelaySendsToGroup(
+        &data_manager_service_, get_request,
+        routing::SingleRelaySource(routing::SingleSource(maid_node_id), maid_node_id,
+                                   routing::SingleSource(maid_node_id)),
+        routing::GroupId(data_name_id)));
+  }
   //  GetResponseFromPmidNodeToDataManager
   {
     NodeId pmid_node_id(RandomString(NodeId::kSize));

--- a/src/maidsafe/vault/tests/tests_utils.h
+++ b/src/maidsafe/vault/tests/tests_utils.h
@@ -135,6 +135,13 @@ void SingleSendsToGroup(ServiceType* service, const MessageType& message,
   service->HandleMessage(message, single_source, group_id);
 }
 
+template <typename ServiceType, typename MessageType>
+void SingleRelaySendsToGroup(ServiceType* service, const MessageType& message,
+                        const routing::SingleRelaySource& single_source,
+                        const routing::GroupId& group_id) {
+  service->HandleMessage(message, single_source, group_id);
+}
+
 template <typename DataNameType>
 std::vector<routing::GroupSource> CreateGroupSource(const DataNameType& data_name) {
   return CreateGroupSource(NodeId(data_name.value.string()));

--- a/src/maidsafe/vault/vault.h
+++ b/src/maidsafe/vault/vault.h
@@ -87,9 +87,6 @@ class Vault {
   bool OnGetFromCache(const T& message);
   template <typename T>
   void OnStoreInCache(const T& message);
-  template <typename Sender, typename Receiver>
-  bool HandleGetFromCache(const nfs::TypeErasedMessageWrapper message, const Sender& sender,
-                          const Receiver& receiver);
 
   std::mutex network_health_mutex_;
   std::condition_variable network_health_condition_variable_;
@@ -114,16 +111,13 @@ class Vault {
 
 template <typename T>
 void Vault::OnMessageReceived(const T& message) {
-//   LOG(kVerbose) << "Vault::OnMessageReceived";
   asio_service_.service().post([=] {
-//     LOG(kVerbose) << "Vault::OnMessageReceived invoked task in asio_service";
     demux_.HandleMessage(message);
   });
 }
 
 template <typename T>
 CacheHandlerService::HandleMessageReturnType Vault::OnGetFromCache(const T& message) {
-  LOG(kVerbose) << "Vault::OnGetFromCache: ";
   auto wrapper_tuple(nfs::ParseMessageWrapper(message.contents));
   return cache_service_.HandleMessage(wrapper_tuple, message.sender, message.receiver);
 }
@@ -132,9 +126,7 @@ template <typename T>
 void Vault::OnStoreInCache(const T& message) {
   // TODO(Team): To investigate the cost of running in new thread (as below) versus allowing
   //             the operation to continue on caller (routing) thread.
-  LOG(kVerbose) << "Vault::OnStoreInCache: ";
   asio_service_.service().post([=] {
-    LOG(kVerbose) << "Vault::OnStoreInCache2: ";
     auto wrapper_tuple(nfs::ParseMessageWrapper(message.contents));
     cache_service_.HandleMessage(wrapper_tuple, message.sender, message.receiver);
   });


### PR DESCRIPTION
notes:
1- the task is improved on 597. However, most of codes related to 597 has been removed as it mainly relied on declaring test as a friend.
2- the task was supposed to cover vault test as well. since the only method in vault class is the constructor, functional tests will cover 